### PR TITLE
Used if return in main.dart. (VB10 issue)

### DIFF
--- a/bootcamp91/lib/main.dart
+++ b/bootcamp91/lib/main.dart
@@ -36,13 +36,11 @@ class _HomeScreen extends StatelessWidget {
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return const Center(child: CircularProgressIndicator());
-        } else if (snapshot.hasData && snapshot.data != null) {
-          return MainScreen(
-              userUid:
-                  snapshot.data!.uid); // Kullanıcı giriş yapmışsa MainScreen
-        } else {
-          return const WelcomeScreen(); // Kullanıcı giriş yapmamışsa WelcomeScreen
         }
+        if (snapshot.hasData && snapshot.data != null) {
+          return MainScreen(userUid: snapshot.data!.uid);
+        }
+        return const WelcomeScreen(); // Diğer tüm durumlar için WelcomeScreen döndürülür
       },
     );
   }


### PR DESCRIPTION
Yeni yönliendirici HomeScreen:

```
class _HomeScreen extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return FutureBuilder<User?>(
      future: _getCurrentUser(),
      builder: (context, snapshot) {
        if (snapshot.connectionState == ConnectionState.waiting) {
          return const Center(child: CircularProgressIndicator());
        }
        if (snapshot.hasData && snapshot.data != null) {
          return MainScreen(userUid: snapshot.data!.uid);
        }
        return const WelcomeScreen(); // Diğer tüm durumlar için WelcomeScreen döndürülür
      },
    );
  }

  Future<User?> _getCurrentUser() async {
    User? user = FirebaseAuth.instance.currentUser;
    return user;
  }
}
```